### PR TITLE
Add GitHub Actions workflow to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 ## Hi there 👋
 
-<!--
+<!--name: Build Training Dashboard
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run training dashboard generator
+      run: |
+        python src/generate_all_advanced.py
+
+    - name: Upload outputs as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dashboard-outputs
+        path: outputs_advanced/
 **kaskis7070/Kaskis7070** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 
 Here are some ideas to get you started:


### PR DESCRIPTION
Added a GitHub Actions workflow for building the training dashboard.
name: Build Training Dashboard

on:
  push:
    branches: [ main ]

jobs:
  build:
    runs-on: ubuntu-latest

    steps:
    - name: Checkout repository
      uses: actions/checkout@v4

    - name: Setup Python
      uses: actions/setup-python@v4
      with:
        python-version: '3.10'

    - name: Install dependencies
      run: |
        python -m pip install --upgrade pip
        pip install -r requirements.txt

    - name: Run training dashboard generator
      run: |
        python src/generate_all_advanced.py

    - name: Upload outputs as artifact
      uses: actions/upload-artifact@v4
      with:
        name: dashboard-outputs
        path: outputs_advanced/